### PR TITLE
Add GravityHelper support to MonumentSpikes

### DIFF
--- a/Code/Module/EmHelper.cs
+++ b/Code/Module/EmHelper.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod.Cil;
+using MonoMod.ModInterop;
 using MonoMod.RuntimeDetour;
 using System;
 using System.Reflection;
@@ -20,6 +21,8 @@ namespace Celeste.Mod.EmHelper.Module {
             On.Celeste.LevelLoader.ctor += LevelLoader_ctor;
             On.Celeste.CassetteBlock.BlockedCheck += Walkeline_BlockedCheck;
             PlayerOrig_updateHook = new ILHook(typeof(Player).GetMethod("orig_Update"), Walkeline_triggerupdate); //i want to swallow burning coals, used to let walkelines interact with triggers, have no idea how it works anymore
+
+            typeof(GravityHelperImports).ModInterop();
         }
 
         private void Walkeline_triggerupdate(ILContext il) {

--- a/Code/Module/GravityHelperImports.cs
+++ b/Code/Module/GravityHelperImports.cs
@@ -1,0 +1,14 @@
+using MonoMod.ModInterop;
+using System;
+
+// ReSharper disable UnassignedField.Global
+
+namespace Celeste.Mod.EmHelper.Module {
+    /// <summary>
+    /// Import methods defined <see href="https://github.com/swoolcock/GravityHelper/blob/develop/GravityHelperExports.cs">GravityHelperExports</see>.
+    /// </summary>
+    [ModImportName("GravityHelper")]
+    public static class GravityHelperImports {
+        public static Func<bool> IsPlayerInverted;
+    }
+}


### PR DESCRIPTION
Uses MonoMod interop to check the player's current gravity state, and applies it to both collisions and ledge blockers.