### PR TITLE
Fix Walkeline hook performance

### DIFF
--- a/Code/Entities/Walkeline.cs
+++ b/Code/Entities/Walkeline.cs
@@ -114,6 +114,11 @@ namespace Celeste.Mod.EmHelper.Entities {
             };
         }
 
+        public override void Awake(Scene scene) {
+            base.Awake(scene);
+            Module.EmHelper.Instance.LevelHasTriggerHappyWalkeline |= TriggerHappy;
+        }
+
         private void OnPlayer(Player player) {
             if (!dead && !inPipe) {
                 if (bouncy) {


### PR DESCRIPTION
Look for Walkeline presence in a level before enabling the expensive trigger hook check. Resolves #1.